### PR TITLE
adjust pubspec, move cbor and rx_command into dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -30,7 +30,7 @@ packages:
     source: hosted
     version: "1.0.5"
   cbor:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: cbor
       url: "https://pub.dartlang.org"
@@ -138,7 +138,7 @@ packages:
     source: hosted
     version: "2.0.0"
   rx_command:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: rx_command
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,13 +10,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  cbor: ^2.0.5
+  rx_command: "^4.3.2+1"
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  cbor: ^2.0.5
   maybe: ^0.4.0
-  rx_command: "^4.3.2+1"
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Fixes compile errors when adding the dependency like so in pubspec.yml

```yml
dependencies:
  ws_action:
    git:
      url: https://github.com/ytitov/flutter-action-ws.git
```